### PR TITLE
handle FileNotFound exceptions for metadata and scoring

### DIFF
--- a/item-review-viewer/src/main/client/package-lock.json
+++ b/item-review-viewer/src/main/client/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@osu-cass/sb-components": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@osu-cass/sb-components/-/sb-components-1.8.2.tgz",
-      "integrity": "sha512-TKmBxZwmQrZvfnqmsEoOCuqbgrQDU3qvPQBRVNLRiSIRQ+/9tAwtu8dffKJmc0i2hW60JQv/hnxgkGrPm+1nfg==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@osu-cass/sb-components/-/sb-components-1.9.1.tgz",
+      "integrity": "sha512-nezttx+PRLhxcTg/AlA1k42uY3ouwlau9i90LPVjRtqT8mIuyNHLQDjJdUFPkjEyNVKguv6Bd6HKUuuYp/ZqQw==",
       "dev": true,
       "requires": {
         "@sbac/sbac-ui-kit": "github:osu-cass/sbac-global-ui-kit#89a6f624183054a7adbaf226544c77297548addd",

--- a/item-review-viewer/src/main/client/src/ItemBankPage.tsx
+++ b/item-review-viewer/src/main/client/src/ItemBankPage.tsx
@@ -6,45 +6,44 @@ import {
     aboutItemRevisionClient,
     revisionsClient,
     sectionsClient
-  } from "./Clients/clients";
+} from "./Clients/clients";
 import {
     itemsMocks
-  } from "./Mocks";
+} from "./Mocks";
 
 
 interface ItemBankPageProps extends RouteComponentProps<ItemRevisionModel> { }
 interface ItemBankPageState {
     itemUrl: string;
 }
+
 export class ItemBankPage extends React.Component<ItemBankPageProps, ItemBankPageState> {
-    constructor ( props: ItemBankPageProps) {
+    constructor ( props: ItemBankPageProps ) {
         super( props );
         this.state = {
             itemUrl: ""
         };
     }
 
-    getItemUrl = ( item: ItemRevisionModel ) => {
+    setItemUrl = ( item: ItemRevisionModel ) => {
         const { itemKey, bankKey, isaap } = item;
         const itemUrl = `${ window.location }ivs/items?ids=${ bankKey }-${ itemKey }`;
         if ( isaap ) {
             itemUrl.concat( itemUrl, `&isaap=${ isaap }` );
         }
-        this.setState( { itemUrl } );
-
-        return itemUrl;
+        this.setState({ itemUrl });
     }
 
     render () {
         return (
             <ItemBankContainer
-            accessibilityClient={accessibilityClient}
-            aboutItemRevisionClient={aboutItemRevisionClient}
-            revisionsClient={revisionsClient}
-            sectionsClient={sectionsClient}
-            itemViewUrl={this.state.itemUrl}
-            getUrl={this.getItemUrl}
-            items={itemsMocks}
-          />);
+                accessibilityClient={accessibilityClient}
+                aboutItemRevisionClient={aboutItemRevisionClient}
+                revisionsClient={revisionsClient}
+                sectionsClient={sectionsClient}
+                itemViewUrl={this.state.itemUrl}
+                setUrl={this.setItemUrl}
+                items={itemsMocks}
+            /> );
     }
 }

--- a/item-review-viewer/src/main/java/org/smarterbalanced/itemreviewviewer/web/services/IGitLabService.java
+++ b/item-review-viewer/src/main/java/org/smarterbalanced/itemreviewviewer/web/services/IGitLabService.java
@@ -1,5 +1,6 @@
 package org.smarterbalanced.itemreviewviewer.web.services;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -17,15 +18,15 @@ public interface IGitLabService {
 
     String unzip(String itemNumber) throws IOException;
 
-    ItemDocument getItemScoring(String itemName);
+    ItemDocument getItemScoring(String itemNumber);
 
-    List<ItemCommit> getItemCommits(String itemName) throws GitLabException;
+    List<ItemCommit> getItemCommits(String itemNumber) throws GitLabException;
 
     List<ItemCommit> getItemCommits(String type, String bankId, String itemNumber) throws GitLabException;
 
     Metadata getMetadata(String itemNumber) throws GitLabException;
 
-    ItemMetadataModel getItemMetadata(String itemId, String section) throws GitLabException;
+    ItemMetadataModel getItemMetadata(String itemId, String section) throws GitLabException, FileNotFoundException;
 
     void downloadAssociatedItems(IITSDocument doc);
 }


### PR DESCRIPTION
When making requests for an item revision, sometimes there is no metadata file so I changed the gitlab service to fall back to the current item metadata. If the Item .xml file does not exist, then we have bigger problems and we need to return a server error. So I throw a `FileNotFound` exception and handle it in the `RenderItemController`.