### PR TITLE
feat(api): add routes to enable rubric images to be served

### DIFF
--- a/item-review-viewer/src/main/java/org/smarterbalanced/itemreviewviewer/web/controllers/RenderItemController.java
+++ b/item-review-viewer/src/main/java/org/smarterbalanced/itemreviewviewer/web/controllers/RenderItemController.java
@@ -29,6 +29,10 @@ import tds.irisshared.repository.IContentBuilder;
 import tds.itemrenderer.data.IITSDocument;
 
 import javax.annotation.PostConstruct;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -233,5 +237,24 @@ public class RenderItemController {
             throw new ScoringException(e.getMessage(), itemId);
         }
 
+    }
+
+    @RequestMapping(value = "/{img}.png", method = RequestMethod.GET)
+    @ResponseBody
+    public byte[] rubricImage(@PathVariable("img") String img,
+                              @RequestParam("itemId") String itemId,
+                              @RequestParam(value = "version", required = false, defaultValue = "") String version) throws Exception {
+        try {
+            String qualifiedItemId;
+            if (version != null && version.trim().length() > 0)
+                qualifiedItemId = "I-" + itemId + "-" + version;
+            else
+                qualifiedItemId = "I-" + itemId;
+            IITSDocument iitsDocument = _contentBuilder.getITSDocument(qualifiedItemId);
+            String path = StringUtils.join(iitsDocument.getBaseUriDirSegments(), File.separator) + File.separator + img + ".png";
+            return Files.readAllBytes(Paths.get(path));
+        } catch (IOException e) {
+            throw new Exception();
+        }
     }
 }

--- a/item-review-viewer/src/main/webapp/WEB-INF/web.xml
+++ b/item-review-viewer/src/main/webapp/WEB-INF/web.xml
@@ -105,6 +105,10 @@
         <servlet-name>item-review-viewer</servlet-name>
         <url-pattern>/ivs/*</url-pattern>
     </servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>item-review-viewer</servlet-name>
+        <url-pattern>/rubricImage/*</url-pattern>
+    </servlet-mapping>
     <servlet>
         <servlet-name>rendererServlet</servlet-name>
         <servlet-class>tds.itemrenderer.webcontrols.rendererservlet.RendererServlet</servlet-class>


### PR DESCRIPTION
The api is updated to have a path for serving rubric images. Previously it was trying to serve them from the static content area, where they do not exist.