### PR TITLE
feat(docker): add dockerfile & compose for local dev

### DIFF
--- a/item-review-viewer/Dockerfile-local
+++ b/item-review-viewer/Dockerfile-local
@@ -24,13 +24,10 @@ COPY server.xml ./conf
 RUN mkdir $CATALINA_HOME/webapps/ROOT
 
 # add tomcat jpda debugging environmental variables
-#ENV JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
 ENV JPDA_ADDRESS="8000"
 ENV JPDA_TRANSPORT="dt_socket"
 
 
 # start tomcat7 with remote debugging
-#EXPOSE 8080
-#ENTRYPOINT ["catalina.sh", "run"]
 EXPOSE 8080 8000
 ENTRYPOINT ["catalina.sh", "jpda", "run"]

--- a/item-review-viewer/Dockerfile-local
+++ b/item-review-viewer/Dockerfile-local
@@ -1,0 +1,36 @@
+FROM tomcat:7-jre7
+
+ARG contentStore=/home/tomcat7/content/
+ARG contextName=ROOT
+
+RUN mkdir -p $contentStore
+RUN mkdir -p $contentStore/gitlab
+RUN mkdir -p $contentStore/gitlab_archive
+COPY ./ItemsPatch.xml $contentStore/gitlab
+
+
+
+
+WORKDIR /usr/local/tomcat/
+
+COPY context.xml ./conf
+RUN  rm -rf webapps/*
+
+
+RUN rm ./conf/server.xml
+COPY server.xml ./conf
+
+# create mount point for volume with application
+RUN mkdir $CATALINA_HOME/webapps/ROOT
+
+# add tomcat jpda debugging environmental variables
+#ENV JPDA_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
+ENV JPDA_ADDRESS="8000"
+ENV JPDA_TRANSPORT="dt_socket"
+
+
+# start tomcat7 with remote debugging
+#EXPOSE 8080
+#ENTRYPOINT ["catalina.sh", "run"]
+EXPOSE 8080 8000
+ENTRYPOINT ["catalina.sh", "jpda", "run"]

--- a/item-review-viewer/docker-compose.yml
+++ b/item-review-viewer/docker-compose.yml
@@ -9,9 +9,6 @@ services:
     image: 'irv'
     container_name: irv
 
-#    environment:
-#      JPDA_ADDRESS: 8000
-#      JPDA_TRANSPORT: dt_socket
     volumes:
       - ./target/item-review-viewer:/usr/local/tomcat/webapps/ROOT
     ports:

--- a/item-review-viewer/docker-compose.yml
+++ b/item-review-viewer/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.3'
+
+services:
+
+  api:
+    build:
+      dockerfile: 'Dockerfile-local'
+      context: .
+    image: 'irv'
+    container_name: irv
+
+#    environment:
+#      JPDA_ADDRESS: 8000
+#      JPDA_TRANSPORT: dt_socket
+    volumes:
+      - ./target/item-review-viewer:/usr/local/tomcat/webapps/ROOT
+    ports:
+      - 8080:8080
+      - 8000:8000 # for remote debugging, necessary?
+    restart:
+      always # always | on_failure


### PR DESCRIPTION
I have added Dockerfile and docker-compose file to match local development environment with production.
Previously, using multiple OSs(Windows, Mac) for development caused case sensitive issues.
Dockerizing app would be the best option to avoid this issue.

Also, docker compose file contains remote debug port(8000) for jpda so that developers will be able to debug running IRV app on the docker container on their local machine.